### PR TITLE
add `--platform linux/arm/v7` option on the instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ In other words, the operation of this Dockerfile and Docker container on the arm
 
 ```
 # cross compile ROS 2 resources
-docker buildx build -t rclex/arm32v7_ros_docker:humble -f Dockerfile.humble .
+docker buildx build --platform linux/arm/v7 -t rclex/arm32v7_ros_docker:humble -f Dockerfile.humble .
 # install vendor resources ex) libspdlog, libtinyxml2 libfmt
-docker buildx build -t rclex/arm32v7_ros_docker_with_vendor_resources:humble -f Dockerfile.with_vendor_resources.humble .
+docker buildx build --platform linux/arm/v7 -t rclex/arm32v7_ros_docker_with_vendor_resources:humble -f Dockerfile.with_vendor_resources.humble .
 ```


### PR DESCRIPTION
Related to https://github.com/rclex/arm32v7_ros_docker/issues/6#issuecomment-2008969639, the option is needed to specify the platform architecture. This is a minor correction, but I want to make it clear on the instructions for our future.

@pojiro Is my understanding correct? 